### PR TITLE
Disconnect resizeMinMaxOpId on disable

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -76,7 +76,7 @@ function enable() {
 function disable() {    
     global.display.disconnect(grabOpBeginId);
     global.display.disconnect(grabOpEndId);
-    global.display.disconnect(resizeMinMaxOpId);
+    global.window_manager.disconnect(resizeMinMaxOpId);
     
     stop_wobbly_timer();
     


### PR DESCRIPTION
resizeMinMaxOpId is a signal handler from the global.window_manager
object, not the global.display one. This patch fixes the disable
function disconnecting this signal handler from the corresponding
object.

This will fix a problem that appears when the user disables the
extension but the wobbly effect for maximize and minize is still there
until the next shell reboot.