### PR TITLE
Add support for GNOME 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,8 @@
     "3.36",
     "3.38",    
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/hermes83/compiz-alike-windows-effect",
   "uuid": "compiz-alike-windows-effect@hermes83.github.com",


### PR DESCRIPTION
Using Fedora 36 beta & GNOME 42, I haven't noticed any regressions, so allow enabling without disabling extension version checking in dconf.